### PR TITLE
performance and stability improvements, bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 4DM-Leveling
 
-This is a bot that replaces mee6 leveling from the 4DM Discord server (invite is [here](https://discord.gg/PGH4jVWN))
+This is a bot that replaces mee6 leveling from the 4DM Discord server (invite is [here](https://discord.gg/pMtZa6AVy2))
 
 
 ## Fetures


### PR DESCRIPTION
 - use correct metric for discord character limit
 - fix levelup messages using data from before levelup
 - remove unecessary database calls for calculating rank
 - use cache for getting the bot channel, then fall back to fetch_channel (instead of iterating over ALL channels and threads)
 - clean up the timeouts periodically, to prevent lsit getting unnecessarily long
 - fix scheduling by moving it to a separate thread